### PR TITLE
Stop making extra server calls. Fixes #6

### DIFF
--- a/src/PHPCouchDB/Database.php
+++ b/src/PHPCouchDB/Database.php
@@ -118,10 +118,10 @@ class Database
         try {
             $response = $this->client->request($verb, $endpoint, ['json' => $doc]);
             if ($response->getStatusCode() == 201 && $response_data = json_decode($response->getBody(), true)) {
-                $id = $response_data['id'];
-                // all good.  Let's fetch the doc and return it
-                $fetched_data = json_decode($this->client->get('/' . $this->db_name . '/' . $id)->getBody(), true);
-                return new Document($this, $fetched_data);
+                $newdoc = new Document($this, $doc);
+                $newdoc->id = $response_data['id'];
+                $newdoc->rev = $response_data['rev'];
+                return $newdoc;
             }
         } catch (\GuzzleHttp\Exception\ConnectException $e) {
             throw new Exception\ServerException(

--- a/src/PHPCouchDB/Document.php
+++ b/src/PHPCouchDB/Document.php
@@ -79,9 +79,12 @@ class Document
 
         try {
             $response = $this->client->request('PUT', $endpoint, ["json" => $doc]);
-            // get a brand new version and return it as a brand new object
-            $newrev = $this->database->getDocById($this->id);
-            return $newrev;
+            if ($response->getStatusCode() == 201 && $response_data = json_decode($response->getBody(), true)) {
+                $newdoc = new Document($this->database, $doc);
+                $newdoc->id = $response_data['id'];
+                $newdoc->rev = $response_data['rev'];
+                return $newdoc;
+            }
         } catch (\GuzzleHTTP\Exception\ClientException $e) {
             // is it a conflict?  Or something else?
             if ($e->getResponse()->getStatusCode() == 409) {

--- a/tests/PHPCouchDB/DatabaseTest.php
+++ b/tests/PHPCouchDB/DatabaseTest.php
@@ -61,10 +61,8 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase
     public function testCreateWithID() {
         $create = '{"ok":true,"id":"abcde12345","rev":"1-928ec193918889e122e7ad45cfd88e47"}';
         $create_response = new Response(201, [], $create);
-        $fetch = '{"_id":"abcde12345","_rev":"1-928ec193918889e122e7ad45cfd88e47","noise":"howl"}';
-        $fetch_response = new Response(200, [], $fetch);
 
-		$mock = new MockHandler([ $this->use_response, $create_response, $fetch_response ]);
+		$mock = new MockHandler([ $this->use_response, $create_response ]);
 		$handler = HandlerStack::create($mock);
 		$client = new Client(['handler' => $handler]);
 
@@ -81,10 +79,8 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase
     public function testCreateWithoutID() {
         $create = '{"ok":true,"id":"95613816b3a7490727388ebb47002c0f","rev":"1-928ec193918889e122e7ad45cfd88e47"}';
         $create_response = new Response(201, [], $create);
-        $fetch = '{"_id":"95613816b3a7490727388ebb47002c0f","_rev":"1-928ec193918889e122e7ad45cfd88e47","noise":"howl"}';
-        $fetch_response = new Response(200, [], $fetch);
 
-		$mock = new MockHandler([ $this->use_response, $create_response, $fetch_response ]);
+		$mock = new MockHandler([ $this->use_response, $create_response ]);
 		$handler = HandlerStack::create($mock);
 		$client = new Client(['handler' => $handler]);
 

--- a/tests/PHPCouchDB/DocumentTest.php
+++ b/tests/PHPCouchDB/DocumentTest.php
@@ -18,18 +18,13 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
 
         $create = '{"ok":true,"id":"abcde12345","rev":"1-928ec193918889e122e7ad45cfd88e47"}';
         $this->create_response = new Response(201, [], $create);
-        $fetch = '{"_id":"abcde12345","_rev":"1-928ec193918889e122e7ad45cfd88e47","noise":"howl"}';
-        $this->fetch_response = new Response(200, [], $fetch);
     }
 
     public function testUpdate() {
         $update = '{"ok":true,"id":"abcde12345","rev":"2-74a0465bd6e3ea40a1a3752b93916762"}';
-        $update_response = new Response(200, [], $update);
+        $update_response = new Response(201, [], $update);
 
-        $fetch2 = '{"_id":"abcde12345","_rev":"1-928ec193918889e122e7ad45cfd88e47","noise":"howl"}';
-        $fetch_response2 = new Response(200, [], $fetch2);
-
-		$mock = new MockHandler([ $this->use_response, $this->create_response, $this->fetch_response, $update_response, $fetch_response2 ]);
+		$mock = new MockHandler([ $this->use_response, $this->create_response, $update_response ]);
 		$handler = HandlerStack::create($mock);
 		$client = new Client(['handler' => $handler]);
 
@@ -54,7 +49,7 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $update = '{"error":"conflict","reason":"Document update conflict."}';;
         $update_response = new Response(409, [], $update);
 
-		$mock = new MockHandler([ $this->use_response, $this->create_response, $this->fetch_response, $update_response ]);
+		$mock = new MockHandler([ $this->use_response, $this->create_response, $update_response ]);
 		$handler = HandlerStack::create($mock);
 		$client = new Client(['handler' => $handler]);
 
@@ -71,10 +66,10 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $delete = '{"ok":true,"id":"abcde12345","rev":"2-74a0465bd6e3ea40a1a3752b93916762"}';
         $delete_response = new Response(200, [], $delete);
 
-        $fetch3 = '{"error":"not_found","reason":"deleted"}';
-        $fetch_response3 = new Response(404, [], $fetch3);
+        $delete2 = '{"error":"not_found","reason":"deleted"}';
+        $delete_response2 = new Response(404, [], $delete2);
 
-		$mock = new MockHandler([ $this->use_response, $this->create_response, $this->fetch_response, $delete_response, $fetch_response3 ]);
+		$mock = new MockHandler([ $this->use_response, $this->create_response, $delete_response, $delete_response2 ]);
 		$handler = HandlerStack::create($mock);
 		$client = new Client(['handler' => $handler]);
 
@@ -99,7 +94,7 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $delete = '{"error":"conflict","reason":"Document update conflict."}';
         $delete_response = new Response(409, [], $delete);
 
-		$mock = new MockHandler([ $this->use_response, $this->create_response, $this->fetch_response, $delete_response ]);
+		$mock = new MockHandler([ $this->use_response, $this->create_response, $delete_response ]);
 		$handler = HandlerStack::create($mock);
 		$client = new Client(['handler' => $handler]);
 


### PR DESCRIPTION
This simply takes the response information and puts the ID and Revision information into a new object with the data we sent to the server.  We assume the server understood and accepted exactly what we sent in order to avoid the extra call.